### PR TITLE
Se arregla el intervalo de las frecuencias,

### DIFF
--- a/TrabajosPracticosSIM/TP_1/Entidades/EstructuraFrecuencias.cs
+++ b/TrabajosPracticosSIM/TP_1/Entidades/EstructuraFrecuencias.cs
@@ -72,7 +72,7 @@ namespace TrabajosPracticosSIM.TP_1.Entidades
 
                 foreach (KeyValuePair<int, double> kvp in lista)
                 {
-                    if (kvp.Value >= subinterv_limite_inf && kvp.Value <= subinterv_limite_sup)
+                    if (kvp.Value >= subinterv_limite_inf && kvp.Value < subinterv_limite_sup)
                         fo++;
                 }
                 

--- a/TrabajosPracticosSIM/TP_1/InterfacesDeUsuario/PantallaPruebaDeFrecuencia.cs
+++ b/TrabajosPracticosSIM/TP_1/InterfacesDeUsuario/PantallaPruebaDeFrecuencia.cs
@@ -148,8 +148,6 @@ namespace TrabajosPracticosSIM.TP_1.InterfacesDeUsuario
 
         private void btn_exportar_Click(object sender, EventArgs e)
         {
-
-            //TRY - CATCHA.
             try
             {
                 DataTable dt = new DataTable();
@@ -218,9 +216,7 @@ namespace TrabajosPracticosSIM.TP_1.InterfacesDeUsuario
             }
             catch (Exception ex)
             {
-
-                MessageBox.Show("Error: "+ ex.Message, "Error Archivo",MessageBoxButtons.OK, MessageBoxIcon.Error);
-
+            MessageBox.Show("Error: "+ ex.Message, "Error Archivo",MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
 


### PR DESCRIPTION
kvp.Value >= subinterv_limite_inf && kvp.Value (<) subinterv_limite_sup

Antes el valor entre parentesis era (<=) por lo que terminaba incluyendo un nro random dos veces si el nro caia en algun limite